### PR TITLE
fix : 운영자 픽 해제 안 되던 문제 해결 (@Param 추가 및 is_selected 타입 대응)

### DIFF
--- a/View/src/pages/mypage/admin/AdminReviewPage.jsx
+++ b/View/src/pages/mypage/admin/AdminReviewPage.jsx
@@ -36,8 +36,7 @@ export default function AdminReviewPage() {
                     content: r.content,
                     price: r.price,
                     isPick:
-                        r.is_selected === 1 ||
-                        r.is_selected === true,
+                        r.is_selected === "1"
                 }));
 
                 setReviews(normalized);
@@ -64,6 +63,7 @@ export default function AdminReviewPage() {
             const k = keyword.toLowerCase();
             base = base.filter(
                 (r) =>
+                    String(r.id).includes(k) || // 리뷰 아이디 검색
                     r.reviewer.toLowerCase().includes(k) ||
                     r.content.toLowerCase().includes(k)
             );
@@ -159,7 +159,7 @@ export default function AdminReviewPage() {
                         </FilterSelect>
 
                         <SearchInput
-                            placeholder="작성자 / 내용 검색"
+                            placeholder="작성자 / 내용 / 리뷰 아이디 검색"
                             value={keyword}
                             onChange={(e) => {
                                 setKeyword(e.target.value);

--- a/src/main/java/com/review/shop/repository/admin/AdminReviewMapper.java
+++ b/src/main/java/com/review/shop/repository/admin/AdminReviewMapper.java
@@ -1,15 +1,19 @@
 package com.review.shop.repository.admin;
 
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
 
 @Mapper
 public interface AdminReviewMapper {
-    //리뷰 소프트 삭제
-    int deleteReview(int review_id);
+    // 리뷰 소프트 삭제
+    int deleteReview(@Param("review_id") int reviewId);
 
-    //운영자 리뷰 선택 여부 설정, (DB에서 넘어오는)is_selected는 can null
-    int setReviewSelection(int review_id, Integer is_selected);
+    // 운영자 리뷰 선택 여부 설정
+    int setReviewSelection(
+            @Param("review_id") int reviewId,
+            @Param("is_selected") Integer isSelected
+    );
 
-    // 운영자 채택 리뷰 선택시 리뷰 작성자의 포인트 적립을 위해 user_id반환
-    int findReviewer(int review_id);
+    // 운영자 픽 시 리뷰 작성자 user_id 반환
+    int findReviewer(@Param("review_id") int reviewId);
 }


### PR DESCRIPTION
### 작업 내용
- AdminReviewMapper에 @Param 추가하여 review_id, is_selected 매핑 오류 수정
- 프론트에서 is_selected 문자열("1"/"0") 정상 처리하도록 로직 보완
- 운영자 픽 설정/해제 모두 정상 반영됨 확인