### PR TITLE
feat: Q&A 관리 UI 개선 및 필터/검색 기능 추가

### DIFF
--- a/View/src/pages/mypage/admin/AdminQnaAnswerPage.jsx
+++ b/View/src/pages/mypage/admin/AdminQnaAnswerPage.jsx
@@ -1,13 +1,16 @@
 import React, { useState, useEffect } from "react";
 import { useLocation, useParams, useNavigate } from "react-router-dom";
 import {
-    Wrap, Inner, Title, QuestionHeader, IconCircle,
-    TextBlock, QuestionText, Meta, AnswerBox, AnswerTitleInput, AnswerTextarea,
-    AnswerButtonWrap, AnswerButton,QuestionContent} from "./adminQnaPage.style";
-import {fetchQnaDetail, updateQnaAnswer,} from "../../../api/admin/adminQnaApi";
+    Wrap, Inner, Content, TitleRow, CenterTitle, BackButton,
+    QuestionHeader, IconCircle, TextBlock, QuestionText, Meta,
+    QuestionContent, AnswerBox, AnswerTitleInput, AnswerTextarea,
+    AnswerButtonWrap, AnswerButton
+} from "./adminQnaPage.style";
+
+import { fetchQnaDetail, updateQnaAnswer } from "../../../api/admin/adminQnaApi";
 
 export default function AdminQnaAnswerPage() {
-    const { id } = useParams(); // URL의 qnaId
+    const { id } = useParams();
     const location = useLocation();
     const navigate = useNavigate();
 
@@ -23,48 +26,28 @@ export default function AdminQnaAnswerPage() {
         }
     );
 
-    const [answerTitle, setAnswerTitle] = useState("");
     const [answerBody, setAnswerBody] = useState("");
 
-    // 상세 데이터 로딩
     useEffect(() => {
-        const loadDetail = async () => {
+        const load = async () => {
             if (stateData) {
                 setQuestion(stateData);
-
-                if (stateData.answer) {
-                    setAnswerBody(stateData.answer);
-                }
-
-                // stateData에는 title/user_name만 있고 content는 없음
-                // content 없으면 detail API 호출 계속 진행
-                if (stateData.content) {
-                    return;        // content 있으면 API 안 불러도 됨
-                }
+                if (stateData.answer) setAnswerBody(stateData.answer);
+                if (stateData.content) return;
             }
 
             try {
                 const res = await fetchQnaDetail(id);
-                console.log("QNA 상세:", res.data);
-                console.log("상세 조회 데이터 키들:", Object.keys(res.data));
-                const q = res.data;
-
-                setQuestion(q);
-
-                // 기존 답변 세팅
-                if (q.answer) {
-                    setAnswerBody(q.answer);
-                }
-
-            } catch (error) {
-                console.error("[ADMIN] QnA 상세 조회 실패:", error);
+                setQuestion(res.data);
+                if (res.data.answer) setAnswerBody(res.data.answer);
+            } catch (e) {
+                console.error("QnA 상세 조회 실패:", e);
             }
         };
 
-        loadDetail();
+        load();
     }, [id, stateData]);
 
-    // 답변 등록/수정
     const handleSubmit = async (e) => {
         e.preventDefault();
 
@@ -72,53 +55,51 @@ export default function AdminQnaAnswerPage() {
             await updateQnaAnswer(question.qna_id, answerBody);
             alert("답변이 등록되었습니다.");
             navigate("/admin/qna");
-        } catch (error) {
-            console.error("[ADMIN] 답변 등록 실패:", error);
-            alert("답변 등록에 실패했습니다.");
+        } catch (e) {
+            alert("답변 등록 실패!");
         }
     };
 
     return (
         <Wrap>
             <Inner>
-                <Title>Q&A 관리</Title>
+                <Content>
 
-                {/* 상단 질문 영역 */}
-                <QuestionHeader>
-                    <IconCircle>?</IconCircle>
-                    <TextBlock>
-                        <QuestionText>{question.title}</QuestionText>
-                        <Meta>상품번호: {question.product_id}</Meta>
-                        <Meta>고객: {question.user_name}</Meta>
-                        <Meta style={{ marginTop: "6px" }}>
-                            작성일: {question.created_at}
-                        </Meta>
-                    </TextBlock>
-                </QuestionHeader>
+                    <TitleRow>
+                        <BackButton onClick={() => navigate(-1)}>← 뒤로가기</BackButton>
+                        <CenterTitle>Q&A 관리</CenterTitle>
+                    </TitleRow>
 
-                <QuestionContent>
-                    {question.content}
-                </QuestionContent>
+                    <QuestionHeader>
+                        <IconCircle>?</IconCircle>
+                        <TextBlock>
+                            <QuestionText>{question.title}</QuestionText>
+                            <Meta>상품번호: {question.product_id}</Meta>
+                            <Meta>고객: {question.user_name}</Meta>
+                            <Meta>
+                                작성일: {question.created_at && question.created_at.slice(0, 16).replace("T", " ")}
+                            </Meta>
+                        </TextBlock>
+                    </QuestionHeader>
 
-                {/* 답변 작성 박스 */}
-                <form onSubmit={handleSubmit}>
-                    <AnswerBox>
-                        <AnswerTitleInput
-                            placeholder="(선택) 답변 제목을 입력해주세요."
-                            value={answerTitle}
-                            onChange={(e) => setAnswerTitle(e.target.value)}
-                        />
-                        <AnswerTextarea
-                            placeholder="답변 내용을 입력해주세요."
-                            value={answerBody}
-                            onChange={(e) => setAnswerBody(e.target.value)}
-                        />
-                    </AnswerBox>
+                    <QuestionContent>{question.content}</QuestionContent>
 
-                    <AnswerButtonWrap>
-                        <AnswerButton type="submit">답변등록</AnswerButton>
-                    </AnswerButtonWrap>
-                </form>
+                    <form onSubmit={handleSubmit}>
+                        <AnswerBox>
+                            <AnswerTitleInput placeholder="(선택) 답변 제목을 입력해주세요." />
+                            <AnswerTextarea
+                                placeholder="답변 내용을 입력해주세요."
+                                value={answerBody}
+                                onChange={(e) => setAnswerBody(e.target.value)}
+                            />
+                        </AnswerBox>
+
+                        <AnswerButtonWrap>
+                            <AnswerButton type="submit">답변등록</AnswerButton>
+                        </AnswerButtonWrap>
+                    </form>
+
+                </Content>
             </Inner>
         </Wrap>
     );

--- a/View/src/pages/mypage/admin/AdminQnaPage.jsx
+++ b/View/src/pages/mypage/admin/AdminQnaPage.jsx
@@ -1,10 +1,10 @@
-// src/pages/mypage/admin/AdminQnaPage.jsx
 import React, { useMemo, useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import {
-    Wrap, Inner, Title, SectionTitle,
-    List, Row, IconCircle, TextBlock,
-    QuestionText, Meta, Pagination, PagerBtn, PageInfo,} from "./adminQnaPage.style";
+    Wrap, Inner, Content, TitleRow, Title,
+    Pagination, PagerBtn, PageInfo,
+    QnaTable, FilterSelect, FilterRow, SearchInput, FilterLabel
+} from "./adminQnaPage.style";
 import { fetchQnaList } from "../../../api/admin/adminQnaApi";
 
 export default function AdminQnaPage() {
@@ -12,82 +12,143 @@ export default function AdminQnaPage() {
     const [page, setPage] = useState(1);
     const pageSize = 10;
     const navigate = useNavigate();
+    const [filterStatus, setFilterStatus] = useState("ALL"); // ALL / WAITING / ANSWERED
+    const [keyword, setKeyword] = useState("");
 
-    // QnA 목록 로딩
     useEffect(() => {
         const load = async () => {
             try {
-                const res = await fetchQnaList();  // axios 응답
-                console.log("QNA 목록 응답:", res);
-
-                // 실제 백엔드 응답에서 data 배열만 추출
+                const res = await fetchQnaList();
                 const items = res.data ?? [];
-
                 setList(Array.isArray(items) ? items : []);
-            } catch (error) {
-                console.error("[ADMIN] QnA 목록 불러오기 실패:", error);
+            } catch (err) {
+                console.error("[ADMIN] QnA 목록 실패", err);
                 setList([]);
             }
         };
-
         load();
     }, []);
+
+    const filteredList = useMemo(() => {
+        let base = [...list];
+
+        // 검색
+        if (keyword.trim()) {
+            const k = keyword.toLowerCase();
+            base = base.filter(q =>
+                q.user_name?.toLowerCase().includes(k) ||
+                q.title?.toLowerCase().includes(k)
+            );
+        }
+
+        // 상태 필터
+        if (filterStatus === "WAITING") {
+            base = base.filter(q => !q.answer);
+        } else if (filterStatus === "ANSWERED") {
+            base = base.filter(q => q.answer);
+        }
+
+        return base;
+    }, [list, filterStatus, keyword]);
+
 
     const total = list.length;
     const maxPage = Math.max(1, Math.ceil(total / pageSize));
 
     const pageList = useMemo(() => {
         const s = (page - 1) * pageSize;
-        return list.slice(s, s + pageSize);
-    }, [list, page]);
+        return filteredList.slice(s, s + pageSize);
+    }, [filteredList, page]);
 
-    const handleClickRow = (item) => {
-        navigate(`/admin/qna/${item.qna_id}`, { state: item });
+    const handleRowClick = (q) => {
+        navigate(`/admin/qna/${q.qna_id}`, { state: q });
     };
+
+
 
 
     return (
         <Wrap>
             <Inner>
-                <Title>Q&A 관리</Title>
-                <SectionTitle>질문 목록</SectionTitle>
+                <Content>
 
-                <List>
-                    {pageList.map((q) => (
-                        <Row key={q.qna_id} onClick={() => handleClickRow(q)}>
-                            <IconCircle status={q.status}>
-                                {q.status === "답변완료" ? "✔" : "?"}
-                            </IconCircle>
-                            <TextBlock>
-                                <QuestionText>{q.title}</QuestionText>
-                                <Meta>고객: {q.user_name}</Meta>
-                                {q.answer && (
-                                    <Meta style={{ color: "#0ea5e9" }}>
-                                        ✔ 답변 완료
-                                    </Meta>
-                                )}
-                            </TextBlock>
-                        </Row>
-                    ))}
-                </List>
+                    <TitleRow>
+                        <Title>Q&A 관리</Title>
+                    </TitleRow>
 
-                <Pagination>
-                    <PagerBtn
-                        disabled={page === 1}
-                        onClick={() => setPage((p) => Math.max(1, p - 1))}
-                    >
-                        {"<"}
-                    </PagerBtn>
-                    <PageInfo>
-                        {page} / {maxPage}
-                    </PageInfo>
-                    <PagerBtn
-                        disabled={page === maxPage}
-                        onClick={() => setPage((p) => Math.min(maxPage, p + 1))}
-                    >
-                        {">"}
-                    </PagerBtn>
-                </Pagination>
+                    <FilterRow>
+
+                        {/* 상태 필터 */}
+                        <FilterLabel>상태</FilterLabel>
+                        <FilterSelect
+                            value={filterStatus}
+                            onChange={(e) => {
+                                setFilterStatus(e.target.value);
+                                setPage(1);
+                            }}
+                        >
+                            <option value="ALL">전체</option>
+                            <option value="WAITING">미답변</option>
+                            <option value="ANSWERED">답변완료</option>
+                        </FilterSelect>
+
+                        {/* 검색창 */}
+                        <SearchInput
+                            placeholder="고객명 / 제목 검색"
+                            value={keyword}
+                            onChange={(e) => {
+                                setKeyword(e.target.value);
+                                setPage(1);
+                            }}
+                        />
+
+                    </FilterRow>
+
+
+                    <QnaTable>
+                        <thead>
+                        <tr>
+                            <th>No.</th>
+                            <th>고객</th>
+                            <th>질문 제목</th>
+                            <th>답변 여부</th>
+                        </tr>
+                        </thead>
+
+                        <tbody>
+                        {pageList.map((q, idx) => {
+                            const rowNumber = (page - 1) * pageSize + idx + 1;
+                            return (
+                                <tr
+                                    key={q.qna_id}
+                                    onClick={() => handleRowClick(q)}
+                                    style={{ cursor: "pointer" }}
+                                >
+                                    <td>{rowNumber}</td>
+                                    <td>{q.user_name}</td>
+                                    <td>{q.title}</td>
+                                    <td style={{ color: q.answer ? "#0ea5e9" : "#b91c1c" }}>
+                                        {q.answer ? "답변완료" : "미답변"}
+                                    </td>
+                                </tr>
+                            );
+                        })}
+                        </tbody>
+                    </QnaTable>
+
+                    <Pagination>
+                        <PagerBtn disabled={page === 1} onClick={() => setPage(p => p - 1)}>
+                            {"<"}
+                        </PagerBtn>
+
+                        <PageInfo>{page} / {maxPage}</PageInfo>
+
+                        <PagerBtn disabled={page === maxPage} onClick={() => setPage(p => p + 1)}>
+                            {">"}
+                        </PagerBtn>
+                    </Pagination>
+
+                </Content>
             </Inner>
         </Wrap>
     );

--- a/View/src/pages/mypage/admin/adminQnaPage.style.js
+++ b/View/src/pages/mypage/admin/adminQnaPage.style.js
@@ -6,18 +6,50 @@ export const Wrap = styled.div`
 `;
 
 export const Inner = styled.div`
-  max-width: 1100px;
+  max-width: 1200px;
   margin: 0 auto;
   padding: 24px 16px 48px;
 `;
 
-export const Title = styled.h1`
-  font-size: 28px;
-  font-weight: 800;
-  margin-bottom: 12px;
+export const Content = styled.section`
+  background: #fff;
+  border-radius: 16px;
+  padding: 24px 24px 32px;
+  box-shadow: 0 4px 12px rgba(15, 23, 42, 0.04);
 `;
 
-export const SectionTitle = styled.h2`
+/* 회원관리와 동일한 TitleRow */
+export const TitleRow = styled.div`
+  position: relative;
+  display: flex;
+  align-items: center;
+  margin-bottom: 18px;
+  height: 40px;
+`;
+
+export const CenterTitle = styled.h2`
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
+  font-size: 24px;
+  font-weight: 800;
+`;
+
+export const BackButton = styled.button`
+  padding: 6px 14px;
+  border-radius: 8px;
+  border: 1px solid #ddd;
+  background: #fff;
+  cursor: pointer;
+  font-size: 14px;
+
+  &:hover {
+    background: #f3f4f6;
+  }
+`;
+
+/* 목록 리스트 */
+export const SectionTitle = styled.h3`
   font-size: 18px;
   font-weight: 700;
   margin-bottom: 16px;
@@ -47,8 +79,8 @@ export const IconCircle = styled.div`
   height: 40px;
   border-radius: 999px;
   background: ${({ status }) =>
-          status === "답변완료" ? "#22c55e" : "#f87171"};
-    display: flex;
+    status === "답변완료" ? "#22c55e" : "#f87171"};
+  display: flex;
   align-items: center;
   justify-content: center;
   color: #fff;
@@ -60,21 +92,23 @@ export const IconCircle = styled.div`
 export const TextBlock = styled.div`
   display: flex;
   flex-direction: column;
-    align-items: flex-start;
-    gap: 4px;
+  align-items: flex-start;
+  gap: 4px;
 `;
 
 export const QuestionText = styled.div`
   font-size: 16px;
   font-weight: 600;
-  margin-bottom: 4px;
 `;
 
 export const Meta = styled.div`
-  font-size: 13px;
-  color: #6b7280;
+    font-size: 13px;
+    color: #555;
+    margin-bottom: 3px;
+    line-height: 1.4;
 `;
 
+/* 페이징 */
 export const Pagination = styled.div`
   display: flex;
   justify-content: center;
@@ -102,14 +136,22 @@ export const PageInfo = styled.span`
   color: #444;
 `;
 
-/* ---------- 답변 작성 페이지 ---------- */
-
+/* 상세 페이지 */
 export const QuestionHeader = styled.div`
   display: flex;
   align-items: flex-start;
   padding: 16px 0 24px;
   border-bottom: 1px solid #e5e7eb;
   margin-bottom: 24px;
+`;
+
+export const QuestionContent = styled.div`
+  white-space: pre-wrap;
+  font-size: 15px;
+  color: #444;
+  margin-top: 16px;
+  margin-bottom: 24px;
+  line-height: 1.6;
 `;
 
 export const AnswerBox = styled.div`
@@ -164,13 +206,62 @@ export const AnswerButton = styled.button`
   cursor: pointer;
 `;
 
-/* ---------- 질문 본문 내용 ---------- */
-export const QuestionContent = styled.div`
-  white-space: pre-wrap;
-  font-size: 15px;
-  color: #444;
-  margin-top: 16px;
-  margin-bottom: 24px;
-  line-height: 1.6;
+export const Title = styled.h2`
+  font-size: 24px;
+  font-weight: 800;
 `;
 
+export const QnaTable = styled.table`
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 14px;
+
+  thead {
+    background-color: #f8f9fb;
+  }
+
+  th,
+  td {
+    padding: 10px 12px;
+    border-bottom: 1px solid #eee;
+    text-align: left;
+    vertical-align: middle;
+  }
+
+  th {
+    font-weight: 600;
+    color: #333;
+  }
+
+  tbody tr:hover {
+    background-color: #fafafa;
+  }
+`;
+
+export const FilterRow = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 20px;
+`;
+
+export const FilterSelect = styled.select`
+  padding: 6px 10px;
+  border-radius: 8px;
+  border: 1px solid #ddd;
+  font-size: 14px;
+`;
+
+export const SearchInput = styled.input`
+  margin-left: auto;
+  padding: 6px 10px;
+  border-radius: 8px;
+  border: 1px solid #ddd;
+  font-size: 14px;
+  min-width: 220px;
+`;
+
+export const FilterLabel = styled.span`
+  font-size: 14px;
+  color: #555;
+`;


### PR DESCRIPTION
### 작업 내용
- 상태 필터(전체 / 미답변 / 답변완료) 추가
- 고객명/질문제목 검색 기능 추가
- 상세 페이지 작성일 표시 형식 개선 (YYYY-MM-DD HH:mm)
- 전체 UI 구성 신고관리 페이지와 맞춰 통일성 강화

### 참고 사항
- **답변 상태(status) 필드는 아직 백엔드 반영 전**
  → 현재는 `answer` 존재 여부로 “답변완료/미답변” 임시 처리 중
  → BE에서 status 추가되면 해당 부분 후속 적용 예정