### PR TITLE
feat: 리뷰 탭 이미지 표시 방식 및 카드 반응형 개선

### DIFF
--- a/View/src/pages/main/components/BaumanProduct/BaumanProduct.css
+++ b/View/src/pages/main/components/BaumanProduct/BaumanProduct.css
@@ -136,8 +136,8 @@
 }
 
 .product-thumb-inner img {
-    width: 70%;
-    height: 70%;
+    width: 100%;
+    height: 100%;
     object-fit: contain;
 }
 
@@ -206,12 +206,6 @@
     align-items: center;
     gap: 6px;
     margin-top: 4px;
-}
-
-.product-discount {
-    font-size: 14px;
-    font-weight: 800;
-    color: #ff2f3b;
 }
 
 .product-price {
@@ -363,7 +357,8 @@
     border: 1px solid #eee;
     border-radius: 12px;
     background: #fff;
-    width: 260px;
+    width: 100%;
+    max-width: 260px;
 }
 
 /* 이미지 박스 */
@@ -371,7 +366,8 @@
     position: relative;
     background: #f4f6ff;
     border-radius: 8px;
-    aspect-ratio: 1 / 1;
+    aspect-ratio: 1/1;
+    width: 100%;
     display: flex;
     align-items: center;
     justify-content: center;
@@ -379,8 +375,8 @@
 }
 
 .review-thumb-inner img {
-    width: 70%;
-    height: 70%;
+    width: 100%;
+    height: 100%;
     object-fit: contain;
 }
 
@@ -423,6 +419,12 @@
 
 /* 리뷰 내용 */
 .review-content-line {
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-height: 40px;
     margin-top: 8px;
     font-size: 14px;
     color: #444;

--- a/View/src/pages/main/components/BaumanProduct/BaumanProduct.jsx
+++ b/View/src/pages/main/components/BaumanProduct/BaumanProduct.jsx
@@ -334,8 +334,6 @@ export default function BaumanProduct() {
                                                 <p className="product-title">{item.name}</p>
 
                                                 <div className="product-price-line">
-                                                    <span className="product-discount">
-                                                        {item.discount.toString().padStart(2, "0")}%</span>
                                                     <span className="product-price">
                                                         {item.price.toLocaleString()}
                                                         <span className="unit"> 원</span>
@@ -406,10 +404,9 @@ export default function BaumanProduct() {
                                                     }
                                                 >
                                                     <div className="review-thumb">
-                                                        <img
-                                                            src={review.imageUrl || dummyData}
-                                                            alt={review.productName}
-                                                        />
+                                                        <div className="review-thumb-inner">
+                                                            <img src={review.imageUrl || dummyData} alt={review.productName} />
+                                                        </div>
                                                     </div>
 
                                                     <div className="review-text-box">


### PR DESCRIPTION
### 작업 내용
- 추천 상품 썸네일 이미지 작게 나오는 부분 정사이즈로 수정
- 리뷰 썸네일 이미지 크게 나오는 부분 정사이즈로 수정
- 추천상품 카드에서 할인율 표시 제거
- review-card-box 고정 width 제거 → 반응형 레이아웃 정상화
- 리뷰 내용 2줄 제한