### PR TITLE
fix: 바우만 추천 로직 전체 안정화 및 UI/페이지네이션 버그 수정

### DIFF
--- a/View/src/api/recommend/recommendApi.js
+++ b/View/src/api/recommend/recommendApi.js
@@ -1,0 +1,12 @@
+// src/api/recommend/baumannApi.js
+import axiosClient from "../axiosClient";
+
+// 로그인한 유저의 바우만 타입 조회
+export const fetchMyBaumannType = () => {
+    return axiosClient.get("/api/auth/my-baumann-type");
+};
+
+// 개별 그룹 추천 (first, second, third, fourth, all까지 포함)
+export const fetchRecommendByGroup = (group) => {
+    return axiosClient.post(`/api/recommendations/${group}`);
+};


### PR DESCRIPTION
###  API 구조 개선
- 기존 BaumanProduct 내부에서 axios를 직접 호출하던 부분 제거
- axiosClient 기반 recommendApi.js 생성하여 fetchMyBaumannType, fetchRecommendByGroup 분리
- ALL/그룹별 추천 요청을 단일 API로 통합해 로직 단순화 및 유지보수성 향상

### 작업 내용
- ALL/그룹별(first/second/third/fourth) 추천 API 요청 정상화
- 태그 전환 시 productPage/reviewPage가 유지되면서 상품이 비어 보이던 문제 해결
- 추천 상품 순서가 매번 랜덤으로 보이던 문제를 ID 정렬로 고정
- activeTag UI 미반영 문제 해결 (태그 클릭 시 색상 정상 표시)
- tagToGroup 매핑 적용으로 정확한 그룹 매핑 처리
- 불필요한 handleTagClick 재호출 제거 (useEffect 최적화)