### PR TITLE
feat: 상품 등록/수정 카테고리 셀렉트 박스로 변경

### DIFF
--- a/View/src/pages/mypage/admin/AdminProductEdit.jsx
+++ b/View/src/pages/mypage/admin/AdminProductEdit.jsx
@@ -19,6 +19,14 @@ const BAUMANN_ID_MAP = {
     __PW: 73, __PT: 74, __P_: 75, __NW: 76, __NT: 77, __N_: 78, ___W: 79, ___T: 80, ____: 81,
 };
 
+const CATEGORY_OPTIONS = [
+    "로션",
+    "앰플",
+    "토너",
+    "크림",
+    "클렌징",
+];
+
 const BAUMANN_CODE_BY_ID = Object.fromEntries(
     Object.entries(BAUMANN_ID_MAP).map(([code, id]) => [id, code])
 );
@@ -307,13 +315,19 @@ export default function AdminProductEdit() {
                                     placeholder="브랜드명"
                                     disabled={isSubmitting}
                                 />
-                                <Input
+                                <Select
                                     name="category"
                                     value={form.category}
                                     onChange={onChange}
-                                    placeholder="예: 크림, 토너"
                                     disabled={isSubmitting}
-                                />
+                                >
+                                    <option value="">선택하세요</option>
+                                    {CATEGORY_OPTIONS.map((cat) => (
+                                        <option key={cat} value={cat}>
+                                            {cat}
+                                        </option>
+                                    ))}
+                                </Select>
                             </div>
                         </Row>
                         <Row>

--- a/View/src/pages/mypage/admin/AdminProductNew.jsx
+++ b/View/src/pages/mypage/admin/AdminProductNew.jsx
@@ -20,6 +20,14 @@ const BAUMANN_ID_MAP = {
     __PW: 73, __PT: 74, __P_: 75, __NW: 76, __NT: 77, __N_: 78, ___W: 79, ___T: 80, ____: 81,
 };
 
+const CATEGORY_OPTIONS = [
+    "로션",
+    "앰플",
+    "토너",
+    "크림",
+    "클렌징",
+];
+
 export default function AdminProductNew() {
     const nav = useNavigate();
     const [isSubmitting, setIsSubmitting] = useState(false);
@@ -274,7 +282,14 @@ export default function AdminProductNew() {
                         </Cell>
                         <Cell>
                             <Label>카테고리</Label>
-                            <Input value={form.category} onChange={onChange("category")} />
+                            <Select value={form.category} onChange={onChange("category")}>
+                                <option value="">선택하세요</option>
+                                {CATEGORY_OPTIONS.map((cat) => (
+                                    <option key={cat} value={cat}>
+                                        {cat}
+                                    </option>
+                                ))}
+                            </Select>
                         </Cell>
                     </Row>
                     <Row>


### PR DESCRIPTION
## 작업 내용
- 상품 등록 페이지 카테고리 입력을 셀렉트 박스로 변경
  - 로션 / 앰플 / 토너 / 크림 / 클렌징 
- 상품 수정 페이지 카테고리 입력도 동일하게 적용
- 기존 전달 값(category 문자열) 및 레이아웃 유지